### PR TITLE
add missing config for Linux-environments

### DIFF
--- a/Build Systems/KickAssembler(C64).sublime-build
+++ b/Build Systems/KickAssembler(C64).sublime-build
@@ -21,7 +21,11 @@
         "env" : { "CLASSPATH":"$CLASSPATH:/Applications/KickAssembler/KickAss.jar"},
         "path": "$PATH:/Applications/VICE/X64.app/Contents/MacOS/"
     },
- 
+    "linux":
+    {
+        "env" : {},
+        "path": ""
+    },
     "variants": [
         {
             // Build and Run (F7)

--- a/Build Systems/KickAssembler(C64).sublime-build
+++ b/Build Systems/KickAssembler(C64).sublime-build
@@ -24,7 +24,7 @@
     "linux":
     {
         "env" : {},
-        "path": ""
+        "path": "$PATH"
     },
     "variants": [
         {


### PR DESCRIPTION
This is a bug for Linux-systems, which will crash the script when a pre-/post-build script is being used.

The (dictionary-)entries `env` and `path` never get set/initialized in `KickAssembler(C64).sublime-build` when running on a Linux-environment.
And then the script crashes when it tries to access `env`.update().

```
    def addPrePostVarsToDict(self, sourceDict, buildMode):
        prePostEnvVars = {
            "kickass_buildmode": buildMode,
...
            }
        sourceDict.get('env').update(prePostEnvVars)
        return sourceDict

```

This PR will fix this by simpy initializing these dict-entries with empty values.