### PR TITLE
fix creation of bin-directory

### DIFF
--- a/kickass_build.py
+++ b/kickass_build.py
@@ -99,7 +99,13 @@ class KickassBuildCommand(sublime_plugin.WindowCommand):
         hasPreCommand = glob.glob(preCommand)
         hasPostCommand =  glob.glob(postCommand)
 
-        os.makedirs("bin", exist_ok=True)
+        # os.makedirs() caused trouble with Python versions < 3.4.1 (see https://docs.python.org/3/library/os.html#os.makedirs);
+        # to avoid abortion (on UNIX-systems) here, we simply wrap the call with a try-except
+        # (the "bin"-directory will be generated anyway via the output-parameter in the compile-command)
+        try:
+            os.makedirs("bin", exist_ok=True)
+        except:
+            pass
 
         self.window.run_command('exec', self.createExecDict(kwargs, buildMode, settings))
 


### PR DESCRIPTION
This is more of a workaround than a fix. ;-)

The `os.makedirs()` method always returns "Permission Denied" on my Linux-environment (Linux Mint 19).
Turns out that this is a known problem with older Python versions.

This PR will prevent the script from crashing; making everything work as expected.