### PR TITLE
New Feature: Setting for default prebuild-/postbuild-path

### DIFF
--- a/KickAssembler (C64).sublime-settings
+++ b/KickAssembler (C64).sublime-settings
@@ -10,6 +10,8 @@
 	"kickass_run_path": "x64",
 	"kickass_debug_path": "x64",
 	"kickass_startup_file_path": "Startup",
-	"kickass_empty_bin_folder_before_build" : "true",
-	"kickass_breakpoint_filename" : "breakpoints.txt"
+	"kickass_empty_bin_folder_before_build": "true",
+	"kickass_breakpoint_filename": "breakpoints.txt",
+	"default_prebuild_path": "",
+	"default_postbuild_path": ""
 }

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -5,5 +5,7 @@
 	"kickass_empty_bin_folder_before_build" : "true",
 	"kickass_breakpoint_filename" : "breakpoints.txt",
 	"kickass_compiled_filename": "${build_file_base_name}.prg",
-	"kickass_output_path" : "bin"
+	"kickass_output_path": "bin",
+	"default_prebuild_path": "",
+	"default_postbuild_path": ""
 }


### PR DESCRIPTION
Another small feature/improvement. ;-)

I pretty much always want to run the same "prebuild.sh" before building/running any ASM-file (simply to execute 'killall x64', etc.).
ATM I have to place a copy of my "prebuild.sh"-file into the folder where the ASM-file resides.
And if I ever change/update my "prebuild.sh"-file I will have to change/udpate all existing copies of it. :(
(I know that I could use symlinks... but the symlinks also will have to be created manually every time; for every directory I intend to build/run a ASM-file. And Windows-users also might not have the possibility of using symlinks.)

With this PR you can define a default-path where the "prebuild.sh"-file is located via a simple settings-entry.
Any "prebuild.sh" located in the ASM-file-directory will still take precedence; but if none is present we also check the default path.

Oh... and all of this also applies for the "postbuild.sh". :)