### PR TITLE
Feature/settings not loaded warning

### DIFF
--- a/kickass_build.py
+++ b/kickass_build.py
@@ -80,6 +80,12 @@ class KickassBuildCommand(sublime_plugin.WindowCommand):
 
     def run(self, **kwargs):
         settings = SublimeSettings(self)
+        if not settings.isLoaded(): 
+            errorMessage = "Settings could not be loaded, please restart Sublime Text."
+            sublime.error_message(errorMessage) 
+            print(errorMessage)
+            return
+
         outputFolder = settings.getSetting("kickass_output_path")
 
         # os.makedirs() caused trouble with Python versions < 3.4.1 (see https://docs.python.org/3/library/os.html#os.makedirs);
@@ -104,10 +110,15 @@ class SublimeSettings():
         # Get the view specific settings
         self.__view_settings = parentCommand.window.active_view().settings()
 
-        self.__default_settings = sublime.load_settings("Preferences.sublime-settings")
+    def isLoaded(self):
+        return self.__getSetting("kickass_output_path") != None
 
-    def getSetting(self, settingKey): 
-        return self.__view_settings.get(settingKey, self.__project_settings.get(settingKey, self.__default_settings.get(settingKey, "")))
+    def getSetting(self, settingKey):
+        setting = self.__getSetting(settingKey)
+        return setting if setting else ""
+
+    def __getSetting(self, settingKey): 
+        return self.__view_settings.get(settingKey, self.__project_settings.get(settingKey, None))
 
     def getSettingAsBool(self, settingKey): 
         return self.getSetting(settingKey).lower() == "true"


### PR DESCRIPTION
Shows a warning if settings cannot be loaded when a build is requested, asking the user to restart Sublime.
This should avoid some strange errors after updating, or switching between cloned and package control install modes.