### PR TITLE
Using kick assemblers odir command line argument

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -13,6 +13,6 @@
 	"kickass_debug_command_x64": "\"${kickass_debug_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}_MonCommands.mon\" ${kickass_debug_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_x64": "\"${kickass_run_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}.vs\" ${kickass_run_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_c64debugger": "\"${kickass_run_path}\" -autojmp -layout 1 -symbols \"${kickass_output_path}/${build_file_base_name}.vs\" -wait 2500 -prg \"${kickass_output_path}/${build_file_base_name}.prg\"",
-	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -vicesymbols -showmem -symbolfiledir \"${kickass_output_path}\" ${kickass_args}",
-	"kickass_compile_debug_additional_args": "-afo :afo=true :usebin=true",
+	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -odir \"${kickass_output_path}\" -vicesymbols -showmem ${kickass_args}",
+	"kickass_compile_debug_additional_args": "-afo :afo=true",
 }

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -13,6 +13,6 @@
 	"kickass_debug_command_x64": "\"${kickass_debug_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}_MonCommands.mon\" ${kickass_debug_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_x64": "\"${kickass_run_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}.vs\" ${kickass_run_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_c64debugger": "\"${kickass_run_path}\" -autojmp -layout 1 -symbols \"${kickass_output_path}/${build_file_base_name}.vs\" -wait 2500 -prg \"${kickass_output_path}/${build_file_base_name}.prg\"",
-	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -odir \"${kickass_output_path}\" -vicesymbols -showmem ${kickass_args}",
+	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -vicesymbols -odir \"${kickass_output_path}\" -showmem ${kickass_args}",
 	"kickass_compile_debug_additional_args": "-afo :afo=true",
 }

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -13,6 +13,6 @@
 	"kickass_debug_command_x64": "\"${kickass_debug_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}_MonCommands.mon\" ${kickass_debug_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_x64": "\"${kickass_run_path}\" -logfile \"${kickass_output_path}/${build_file_base_name}_ViceLog.txt\" -moncommands \"${kickass_output_path}/${build_file_base_name}.vs\" ${kickass_run_args} \"${kickass_output_path}/${build_file_base_name}.prg\"",
 	"kickass_run_command_c64debugger": "\"${kickass_run_path}\" -autojmp -layout 1 -symbols \"${kickass_output_path}/${build_file_base_name}.vs\" -wait 2500 -prg \"${kickass_output_path}/${build_file_base_name}.prg\"",
-	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -vicesymbols -odir \"${kickass_output_path}\" -showmem ${kickass_args}",
+	"kickass_compile_args": "\"${build_file_base_name}.${file_extension}\" -log \"${kickass_output_path}/${build_file_base_name}_BuildLog.txt\" -o \"${kickass_output_path}/${build_file_base_name}.prg\" -vicesymbols -showmem -odir \"${kickass_output_path}\" ${kickass_args}",
 	"kickass_compile_debug_additional_args": "-afo :afo=true",
 }


### PR DESCRIPTION
Using kick assemblers odir command line argument in default kick ass command.
Preparation for segment support.