### PR TITLE
Added encoding to preferences

### DIFF
--- a/Build Systems/KickAssembler(C64).sublime-build
+++ b/Build Systems/KickAssembler(C64).sublime-build
@@ -1,7 +1,7 @@
 {
     "selector": "source.assembly.kickassembler",
     "shell": true,
-    "encoding": "cp1252", //Windows: Needed
+    //"encoding": "utf-8", //Windows: cp1252, not used at all?
     "file_regex": "^\\s*\\((.+\\.\\S+)\\s(\\d*):(\\d*)\\)\\s(.*)", //filename, line number, column number and error message
 
     //Settings,
@@ -39,13 +39,13 @@
             "buildmode" : "build-debug",
         },
 
-        { 
+        {
             // Build and Run startup (F5)
             "name": "Build and Run Startup",
             "buildmode" : "build-run-startup",
         },
 
-        { 
+        {
             // Build and Debug startup (Shift+F5)
             "name": "Build and Debug Startup",
             "buildmode" : "build-debug-startup",

--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -1,4 +1,4 @@
-{	
+{
 	"kickass_run_path": "x64",
 	"kickass_debug_path": "x64",
 	"kickass_startup_file_path": "Startup",
@@ -6,6 +6,7 @@
 	"kickass_breakpoint_filename" : "breakpoints.txt",
 	"kickass_compiled_filename": "${build_file_base_name}.prg",
 	"kickass_output_path": "bin",
+	"kickass_encoding": "utf-8",
 	"default_prebuild_path": "",
 	"default_postbuild_path": "",
 	"default_make_path": "",


### PR DESCRIPTION
I've encountered a Bug on MacOS catalina: If no encoding is set, the build fails with an error like this:
> /bin/sh: -c: line 0: unexpected EOF while looking for matching `''
> /bin/sh: -c: line 1: syntax error: unexpected end of file
> [Finished in 0.0s with exit code 2]
> [cmd: echo 'ascii' codec can't decode byte 0xc3 in position 2747: ordinal not in range(128)]

So I did added an encoding option to the preferences and added it to the appropriate function. The editor also took the liberty to remove some trailing whitespaces :)