### PR TITLE
Feature/startup file build annotation

### DIFF
--- a/kickass_build.py
+++ b/kickass_build.py
@@ -91,9 +91,12 @@ class KickassBuildCommand(sublime_plugin.WindowCommand):
 
     def getFilenameVariables(self, buildMode, settings, variables):
         useStartup = 'startup' in buildMode
-        fileToBuild = settings.getSetting("kickass_startup_file_path") if useStartup else variables["file_base_name"]
+        currentFilePath = variables["file"]
+        currentFileBuildAnnotations = self.parseAnnotations(currentFilePath)
+        startupFileAnnotation = currentFileBuildAnnotations.get("startup-file") if currentFileBuildAnnotations else None
+        fileToBuild = (startupFileAnnotation if startupFileAnnotation else settings.getSetting("kickass_startup_file_path")) if useStartup else variables["file_base_name"]
         fileToBuildPath = "%s/%s.%s" % (variables["file_path"], fileToBuild, variables["file_extension"])
-        buildAnnotations = self.parseAnnotations(fileToBuildPath)
+        buildAnnotations = self.parseAnnotations(fileToBuildPath) if useStartup else currentFileBuildAnnotations
         fileToRunAnnotation = buildAnnotations.get("file-to-run") if buildAnnotations else None
         return {
             "build_file_base_name": fileToBuild,

--- a/tests/test_kickass_build.py
+++ b/tests/test_kickass_build.py
@@ -1,7 +1,13 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, create_autospec, PropertyMock
-from testsettings import TestSettings
-from testglobals import kickassbuild, default_settings_dict, default_variables_dict, mock_open34, CopyingMock
+try:
+    from tests.testsettings import TestSettings
+except ImportError:
+    from testsettings import TestSettings
+try:
+    from tests.testglobals import kickassbuild, default_settings_dict, default_variables_dict, mock_open34, CopyingMock
+except ImportError:
+    from testglobals import kickassbuild, default_settings_dict, default_variables_dict, mock_open34, CopyingMock
 
 def createCommand_mock(command_text='test-command-text'):
     return fix_createCommand_mock(create_autospec(kickassbuild.KickAssCommand), command_text)

--- a/tests/test_kickass_build.py
+++ b/tests/test_kickass_build.py
@@ -414,6 +414,18 @@ class TestKickassBuildCommand(TestCase):
         actual = self.target.getFilenameVariables('build', settings, default_variables_dict.copy())
         self.assertEqual({'build_file_base_name': 'test-file', 'start_filename': 'test-file.prg'}, actual)
 
+    @patch('SublimeKickAssemblerC64.kickass_build.KickassBuildCommand.parseAnnotations', autospec=True, return_value={'startup-file': 'test-startup-path/test-startup-file.ext'})
+    def test_getFilenameVariables_buildmode_has_startup_and_has_startupfile_annotation_returns_correct_dictionary(self, parseannotations_mock):
+        settings = TestSettings({'kickass_startup_file_path': 'test-startup-base-name', 'kickass_compiled_filename': 'test-file.prg'})
+        actual = self.target.getFilenameVariables('build-startup', settings, default_variables_dict.copy())
+        self.assertEqual({'build_file_base_name': 'test-startup-path/test-startup-file.ext', 'start_filename': 'test-file.prg'}, actual)
+
+    @patch('SublimeKickAssemblerC64.kickass_build.KickassBuildCommand.parseAnnotations', autospec=True, return_value={'startup-file': 'test-startup-path/test-startup-file.ext'})
+    def test_getFilenameVariables_buildmode_does_not_have_startup_and_has_startupfile_annotation_returns_correct_dictionary(self, parseannotations_mock):
+        settings = TestSettings({'kickass_startup_file_path': 'test-startup-base-name', 'kickass_compiled_filename': 'test-file.prg'})
+        actual = self.target.getFilenameVariables('build', settings, default_variables_dict.copy())
+        self.assertEqual({'build_file_base_name': 'test-file', 'start_filename': 'test-file.prg'}, actual)
+
     #System tests
     #TODO: Maybe rework or move createExecDict system tests for all build modes, another file?
 

--- a/tests/test_kickass_build.py
+++ b/tests/test_kickass_build.py
@@ -327,13 +327,13 @@ class TestKickassBuildCommand(TestCase):
         self.assertEqual({'c':'d'}, dict2)
 
     @patch('builtins.open', new_callable=mock_open34, read_data='.filenamespace goatPowerExample')
-    def test_parseAnnotations_open_is_called_oince(self, open_mock):
+    def test_parseAnnotations_open_is_called_once(self, open_mock):
         filename = 'test-file.asm'
         actual = self.target.parseAnnotations(filename)
         open_mock.assert_called_once_with(filename, 'r')
 
     @patch('builtins.open', new_callable=mock_open34, read_data='.filenamespace goatPowerExample')
-    def test_parseAnnotations_readline_is_called_oince(self, open_mock):
+    def test_parseAnnotations_readline_is_called_once(self, open_mock):
         actual = self.target.parseAnnotations('test-file.asm')
         open_mock.return_value.readline.assert_called_once_with()
 

--- a/tests/test_kickasscommand.py
+++ b/tests/test_kickasscommand.py
@@ -1,5 +1,8 @@
 from unittest import TestCase
-from testglobals import kickassbuild
+try:
+    from tests.testglobals import kickassbuild
+except ImportError:
+    from testglobals import kickassbuild
 
 class TestKickAssCommand(TestCase):
 

--- a/tests/test_kickasscommandfactory.py
+++ b/tests/test_kickasscommandfactory.py
@@ -1,7 +1,13 @@
 from unittest import TestCase
 from unittest.mock import patch, create_autospec
-from testglobals import kickassbuild, default_settings_dict
-from testsettings import TestSettings
+try:
+    from tests.testglobals import kickassbuild, default_settings_dict
+except ImportError:
+    from testglobals import kickassbuild, default_settings_dict
+try:
+    from tests.testsettings import TestSettings
+except ImportError:
+    from testsettings import TestSettings
 
 class TestKickAssCommandFactory(TestCase):
 

--- a/tests/test_sublimesettings.py
+++ b/tests/test_sublimesettings.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from testglobals import kickassbuild
+try:
+    from tests.testglobals import kickassbuild
+except ImportError:
+    from testglobals import kickassbuild
 
 class TestSublimeSettings(TestCase):
     def setUp(self):

--- a/tests/testglobals.py
+++ b/tests/testglobals.py
@@ -18,7 +18,7 @@ default_variables_dict = {
     #'platform': 'Windows', 
     #'packages': 'C:\\Users\\SimonOskarsson\\AppData\\Roaming\\Sublime Text 3\\Packages', 
     #'folder': filePath, 
-    #'file': filePath+'test-file.asm', 
+    'file': 'test-path/test-file.asm', 
     'file_extension': 'asm', 
     'file_path': 'test-path', 
     'file_base_name': 'test-file'


### PR DESCRIPTION
Closes #57 
New feature: startup-file build annotion

- Put startup-file annotation on first line of a file to configure "main entry point", eg. which file is actually compiled. 
-   Has precedence over setting kickass_startup_file_path.
-   Usage: `// @kickass-build "startup-file": "filename.prg"`
 